### PR TITLE
Implement notifications to stdout and a example consumer for my test repo

### DIFF
--- a/github-email-notifications/config.py
+++ b/github-email-notifications/config.py
@@ -1,1 +1,1 @@
-config = dict(githubconsumer=True)
+config = dict(testrepoconsumer=True)

--- a/github-email-notifications/githubconsumer.py
+++ b/github-email-notifications/githubconsumer.py
@@ -5,10 +5,36 @@ import fedmsg.consumers
 
 from pprint import pprint
 
+def get_from_dict(data_dict, key_list):
+    return reduce(lambda d, k: d[k], key_list, data_dict)
+
+class StdoutFormatter(object):
+    def fmt_issue_comment(self, comment):
+        # this could be mail subject
+        print "{comment_author} commented on a pull request".format(**comment)
+        # this could be mail body
+        print comment['comment_body']
+        print "See the full comment at {comment_url}\n".format(**comment)
+
+    def fmt_pr(self, pull_req):
+        # this could be mail subject
+        print "{pr_author}'s pull request #{pr_num}: \"{pr_title}\" was {pr_action}\n".format(**pull_req)
+        # this could be mail body
+        if pull_req['pr_action'] == u'opened':
+            print "PR body:\n{pr_body}\n".format(**pull_req)
+        print "See the full pull-request at {pr_url}\n".format(**pull_req)
+
+class RawPPFormatter(object):
+    def fmt_issue_comment(self, comment):
+        pprint(comment)
+
+    def fmt_pr(self, action, pull_req):
+        pprint(pull_req)
 
 class GithubConsumer(fedmsg.consumers.FedmsgConsumer):
     topic = 'org.fedoraproject.prod.github.*'
     config_key = 'githubconsumer'
+    formatter_cls = RawPPFormatter
 
     def __init__(self, *args, **kw):
         super(GithubConsumer, self).__init__(*args, **kw)
@@ -17,26 +43,77 @@ class GithubConsumer(fedmsg.consumers.FedmsgConsumer):
             'org.fedoraproject.prod.github.issue.comment': self.issue_comment,
             'org.fedoraproject.prod.github.issue.labeled': self.issue_labeled,
             'org.fedoraproject.prod.github.pull_request.opened': self.pr_opened,
+            'org.fedoraproject.prod.github.pull_request.reopened': self.pr_reopened,
             'org.fedoraproject.prod.github.pull_request.closed': self.pr_closed,
+            'org.fedoraproject.prod.github.pull_request.review_comment': self.pr_review,
             'org.fedoraproject.prod.github.status': self.status,
         }
+        self.repo_name = None
+        self.formatter = self.formatter_cls()
 
-    def issue_comment(self, msg):
-        pprint(msg)
+    def _format_msg(self, filter_map, gh_msg):
+        msg = dict()
+        for fld, klist in filter_map.iteritems():
+            msg[fld] = get_from_dict(gh_msg, klist)
+        return msg
+
+    def _pr_handler(self, gh_msg):
+        filter_map = { 'pr_url' : ['body', 'msg', 'pull_request', 'html_url'],
+                       'pr_author' : ['body', 'msg', 'pull_request', 'user', 'login'],
+                       'pr_title' : ['body', 'msg', 'pull_request', 'title'],
+                       'pr_body' : ['body', 'msg', 'pull_request', 'body'],
+                       'pr_num' : ['body', 'msg', 'number'],
+                       'pr_action' : ['body', 'msg', 'action'] }
+        msg = self._format_msg(filter_map, gh_msg)
+        return self.formatter.fmt_pr(msg)
+
+    def issue_comment(self, gh_msg):
+        pr_link = get_from_dict(gh_msg, ['body', 'msg', 'issue', 'pull_request'])
+        if not pr_link:
+            # We only care about comments in pull-requests
+            return
+
+        filter_map = { 'comment_url' : ['body', 'msg', 'comment', 'html_url'],
+                       'comment_author' : ['body', 'msg', 'comment', 'user', 'login'],
+                       'comment_body' : ['body', 'msg', 'comment', 'body'] }
+        msg = self._format_msg(filter_map, gh_msg)
+        return self.formatter.fmt_issue_comment(msg)
 
     def issue_labeled(self, msg):
         pass
 
-    def pr_opened(self, msg):
-        pprint(msg)
+    def pr_opened(self, gh_msg):
+        return self._pr_handler(gh_msg)
 
-    def pr_closed(self, msg):
-        pprint(msg)
+    def pr_closed(self, gh_msg):
+        return self._pr_handler(gh_msg)
+
+    def pr_reopened(self, gh_msg):
+        return self._pr_handler(gh_msg)
+
+    def pr_review(self, msg):
+        pass
 
     def status(self, msg):
         pass
 
+    def _repo_match(self, msg):
+        if self.repo_name is None:
+            return True
+
+        msg_repo = get_from_dict(msg,
+                                 ['body', 'msg', 'repository', 'full_name'])
+        if msg_repo == self.repo_name:
+            return True
+
+        return False
+
     def consume(self, msg):
+        if not self._repo_match(msg):
+            # Not our repo
+            return
+
+        pprint(msg)
         method = self.topic_mapping.get(msg.get('topic'))
         if method:
             method(msg)

--- a/github-email-notifications/githubconsumer.py
+++ b/github-email-notifications/githubconsumer.py
@@ -117,3 +117,11 @@ class GithubConsumer(fedmsg.consumers.FedmsgConsumer):
         method = self.topic_mapping.get(msg.get('topic'))
         if method:
             method(msg)
+
+class TestRepoConsumer(GithubConsumer):
+    config_key = 'testrepoconsumer'
+    repo_name = u'jhrozek/testrepo'
+    formatter_cls = StdoutFormatter
+
+    def __init__(self, *args, **kw):
+        super(TestRepoConsumer, self).__init__(*args, **kw)

--- a/github-email-notifications/setup.py
+++ b/github-email-notifications/setup.py
@@ -15,5 +15,6 @@ setup(
     entry_points="""
     [moksha.consumer]
     githubconsumer = githubconsumer:GithubConsumer
+    testrepoconsumer = githubconsumer:TestRepoConsumer
     """,
 )


### PR DESCRIPTION
Hi,

the attached two patches expand on Martin's work and implement a consumer with pluggable formatters. Currently there is a pretty-print formatter suitable for testing and a stdout formatter that shows how I propose the e-mail notifications could be formatted.

The second patch shows how we could instantiate per-project consumers. tl;dr, the consumer just links to a repo and selects a formatter. I guess we could have a listener for freeipa and a listener for sssd, with the same configuration.

If this is accepted, we only need to:
1. implement a MailFormatter
2. run this script somewhere
3. Profit!
