### PR TITLE
Generate PKINIT certificates among the others

### DIFF
--- a/makepki.sh
+++ b/makepki.sh
@@ -15,6 +15,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 domain=example.com
+realm=${domain^^}
 server1=server1.example.com
 server2=server2.example.com
 client=client.example.com
@@ -29,6 +30,19 @@ profile_server_request_options=(-4)
 profile_server_request_input="\$'1\n7\nfile://'\$(readlink -f \$dbdir)/\$ca.crl\$'\n-1\n-1\n-1\nn\nn\n'"
 profile_server_create_options=(-v 12)
 profile_server_add_options=(-t ,,)
+
+write_chain() {
+    local nick="$1"
+
+    chain=`certutil -O -d $dbdir -n "$nick" |
+             sed -e '/^\s*$/d' -e "s/\s*\"\(.*\)\" \[.*/\1/g"`
+
+    while read -r name; do
+        # OpenSSL requires a reverse order to what we get from NSS
+        echo -e "`certutil -L -d "$dbdir" -n "$name" -a`\n`cat $dbdir/$nick.pem`
+        " > "$dbdir/$nick.pem"
+    done <<< "$chain"
+}
 
 gen_cert() {
     local profile="$1" nick="$2" subject="$3" ca request_options request_input create_options serial add_options pwfile noise csr crt
@@ -71,7 +85,7 @@ gen_cert() {
     certutil -A -d "$dbdir" -n "$nick" -f "$pwfile" -i "$crt" "${add_options[@]}"
 
     mkdir -p "$(dirname $dbdir/$nick.pem)"
-    certutil -L -d "$dbdir" -n "$nick" -a >"$dbdir/$nick.pem"
+    write_chain "$nick"
     pk12util -o "$dbdir/$nick.p12" -n "$nick" -d "$dbdir" -k "$pwfile" -w "$pwfile"
 
     rm -f "$pwfile" "$noise" "$csr" "$crt"
@@ -117,12 +131,60 @@ gen_server_certs() {
     revoke_cert "$nick-revoked"
 }
 
+gen_pkinit_extensions() {
+   echo "[kdc_cert]
+basicConstraints=CA:FALSE
+keyUsage=nonRepudiation,digitalSignature,keyEncipherment,keyAgreement
+extendedKeyUsage=TLS Web Server Authentication, 1.3.6.1.5.2.3.5
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+issuerAltName=issuer:copy
+subjectAltName=otherName:1.3.6.1.5.2.2;SEQUENCE:kdc_princ_name
+
+[kdc_princ_name]
+realm=EXP:0,GeneralString:${realm}
+principal_name=EXP:1,SEQUENCE:kdc_principal_seq
+
+[kdc_principal_seq]
+name_type=EXP:0,INTEGER:1
+name_string=EXP:1,SEQUENCE:kdc_principals
+
+[kdc_principals]
+princ1=GeneralString:krbtgt
+princ2=GeneralString:${realm}" > "$dbdir/ext.kdc"
+}
+
+gen_pkinit_cert() {
+    local nick="$1" subj="$2" outname="$3"
+    shift 3
+
+    openssl genrsa -out "$dbdir/$nick/kdc.key" 2048 > /dev/null
+    openssl req -new -out "$dbdir/$nick/kdc.req" -key "$dbdir/$nick/kdc.key" \
+    -subj "$subj"
+
+    openssl pkcs12 -in "$dbdir/$nick.p12" -passin "pass:$password" \
+    -nodes -nocerts -out "$dbdir/$nick.key" > /dev/null
+
+    openssl x509 -req -in "$dbdir/$nick/kdc.req" \
+    -CAkey "$dbdir/$nick.key" -CA "$dbdir/$nick.pem" \
+    -out "$dbdir/$nick/kdc.crt" -days 365 \
+    -extfile "$dbdir/ext.kdc" -extensions kdc_cert -CAcreateserial > /dev/null
+
+    rm "$dbdir/$nick/kdc.req"
+
+    openssl pkcs12 -export -in "$dbdir/$nick/kdc.crt" \
+    -inkey "$dbdir/$nick/kdc.key" -password "pass:$password" \
+    -out "$dbdir/$nick/$outname.p12" -chain -CAfile "$dbdir/$nick.pem"
+}
+
 gen_subtree() {
     local nick="$1" org="$2"
     shift 2
 
     gen_cert ca "$nick" "CN=CA,O=$org" "$@"
     gen_cert server "$nick/wildcard" "CN=*.$domain,O=$org"
+    gen_pkinit_cert "$nick" "/O=$realm/CN=$server1" "pkinit-server"
+    gen_pkinit_cert "$nick" "/O=$realm/CN=$server2" "pkinit-replica"
     gen_server_certs "$nick/server" "$server1" "$org"
     gen_server_certs "$nick/replica" "$server2" "$org"
     gen_server_certs "$nick/client" "$client" "$org"
@@ -130,6 +192,7 @@ gen_subtree() {
 
 gen_cert server server-selfsign "CN=$server1,O=Self-signed"
 gen_cert server replica-selfsign "CN=$server2,O=Self-signed"
+gen_pkinit_extensions
 gen_subtree ca1 'Example Organization'
 gen_subtree ca1/subca 'Subsidiary Example Organization'
 gen_subtree ca2 'Other Example Organization'


### PR DESCRIPTION
We are generating the PKINIT certificates with OpenSSL tools,
therefore writing the whole cert-chain to a file had to be
implemented.