### PR TITLE
Create pkcs12 files as a part of makepki.sh

### DIFF
--- a/makepki.sh
+++ b/makepki.sh
@@ -18,6 +18,19 @@ dir=pki
 dbdir=nssdb
 password=password
 
+getchain() {
+    local file="$1" cafiles=""
+    shift 1
+
+    while [ "`dirname $file`" != "$dir" ]; do
+        file="`dirname $file`.crt"
+        if [ -f "$file" ]; then
+            cafiles="$cafiles -certfile \"$file\""
+        fi
+    done
+    echo $cafiles
+}
+
 if [ ! -d "$dir" ]; then
     scriptdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
     "$scriptdir"/makepki.py
@@ -36,13 +49,17 @@ find "$dir" -name \*.crt | while read certfile; do
     keyfile="${basename}.key"
     crlfile="${basename}.crl"
     nick="${basename#${dir}/}"
+    chain="`getchain $certfile`"
+    p12file="${basename}.p12"
 
-    p12file="$(mktemp)"
+    echo "Creating $p12file from cert $cafile"
+    export_command="openssl pkcs12 -export -out \"$p12file\" -in \"$certfile\"
+                    -inkey \"$keyfile\" -name \"$nick\"
+                    -passout pass:\"$password\" -passin file:\"$pwfile\"
+                    $chain"
 
-    openssl pkcs12 -export -out "$p12file" -in "$certfile" -inkey "$keyfile" -name "$nick" -passout pass: -passin file:"$pwfile"
-    pk12util -i "$p12file" -d "$dbdir" -k "$pwfile" -W ''
-
-    rm -f "$p12file"
+    eval $export_command
+    pk12util -i "$p12file" -d "$dbdir" -k "$pwfile" -W "$password"
 
     if [ -f "$crlfile" ]; then
         certutil -d "$dbdir" -M -n "$nick" -t CT,C,C


### PR DESCRIPTION
One of the purposes of the makepki.sh script is to simplify creating
certificate files for FreeIPA testing installations. To do that, we
need to generate pkcs12 files aside from just certificates/NSS DB.
This patch brings back the behavior that was there previously.