### PR TITLE
Add Subject Key Identifier extension

### DIFF
--- a/makepki.py
+++ b/makepki.py
@@ -19,6 +19,7 @@ import datetime
 import itertools
 import os
 import os.path
+import base64
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -130,6 +131,10 @@ def profile_ca(builder, ca_nick):
                     reasons=None,
                 ),
         ]),
+        critical=False,
+    )
+    builder = builder.add_extension(
+        x509.SubjectKeyIdentifier(digest = base64.b64encode(os.urandom(64))),
         critical=False,
     )
 


### PR DESCRIPTION
We now require Subject Key Identifier extension in CA
certificates.

Signed-off-by: Michal Reznik <mreznik@redhat.com>