### PR TITLE
ipatool: fixes and enhancements for 'backport' command

### DIFF
--- a/ipatool
+++ b/ipatool
@@ -906,13 +906,10 @@ def sorted_commits(commits):
 
 
 def backport(ctx, repo, pr):
-    try:
-        backport_branches = ctx.options['--backport']
-    except KeyError:
-        try:
-            backport_branches = ctx.options['--branch']
-        except KeyError:
-            return
+    backport_branches = (
+        set(ctx.options.get('--backport', []))
+        | set(ctx.options.get('--branch', []))
+    )
 
     try:
         ctx.config['remote']

--- a/ipatool
+++ b/ipatool
@@ -12,7 +12,7 @@ Usage:
   ipatool [options] [-v...] pr-list [--state=(open|closed|all)]... [--label=NAME...]
   ipatool [options] [-v...] pr-push PR_ID [--backport=BRANCH...] [--reviewer=NAME...]
   ipatool [options] [-v...] pr-reject PR_ID --comment=TEXT
-  ipatool [options] [-v...] backport PR_ID --branch=BRANCH
+  ipatool [options] [-v...] backport PR_ID --branch=BRANCH...
 
 Common Options:
   -h, --help           Display this help and exit

--- a/ipatool
+++ b/ipatool
@@ -1019,7 +1019,7 @@ def backport_command(ctx):
     if 'rejected' in labels:
         ctx.die('Pull request is rejected')
 
-    if not pr.mergeable:
+    if 'pushed' not in labels and not pr.mergeable:
         ctx.die('Pull request is not mergeable.')
 
     most_recent_results = {}


### PR DESCRIPTION
```
a56114b (Fraser Tweedale, 3 minutes ago)
   ipatool: allow backport of pushed PR

   A pushed PR may not be mergeable (due to conflict or nothing to do). But we
   may still want to create a backport for it.  Skip the mergeable check for
   pushed PRs.

f19c9d5 (Fraser Tweedale, 9 minutes ago)
   ipatool: backport: allow multiple target branches

f2bf562 (Fraser Tweedale, 12 minutes ago)
   ipatool: fix backport command

   ctx.options['--backport'] is the empty list when running the
   'backport' command (which uses the '--branches' option instead). And
   vice-versa.  Handle both commands by merging the arguments.
```