### PR TITLE
ipatool: add pr-push --autobackport flag

### DIFF
--- a/ipatool
+++ b/ipatool
@@ -908,12 +908,7 @@ def sorted_commits(commits):
     return result
 
 
-def backport(ctx, repo, pr):
-    backport_branches = (
-        set(ctx.options.get('--backport', []))
-        | set(ctx.options.get('--branch', []))
-    )
-
+def backport(ctx, backport_branches, repo, pr):
     try:
         ctx.config['remote']
         ctx.config['gh-fork-remote']
@@ -1049,7 +1044,7 @@ def backport_command(ctx):
         delete_patches(target_dir)
         ctx.die('Failed to get patch(es): {}'.format(e))
 
-    backport(ctx, repo, pr)
+    backport(ctx, ctx.options.get('--branch', []), repo, pr)
     delete_patches(target_dir)
 
 
@@ -1133,7 +1128,7 @@ def pr_push_command(ctx):
             print("Closing pull request {}".format(pr.number))
             pr_is.close()
 
-            backport(ctx, repo, pr)
+            backport(ctx, ctx.options.get('--backport', []), repo, pr)
     finally:
         delete_patches(target_dir)
 

--- a/ipatool
+++ b/ipatool
@@ -10,7 +10,7 @@ Usage:
   ipatool [options] [-v...] am [--] [PATCH ...]
   ipatool [options] [-v...] pr-ack PR_ID [--comment=TEXT]
   ipatool [options] [-v...] pr-list [--state=(open|closed|all)]... [--label=NAME...]
-  ipatool [options] [-v...] pr-push PR_ID [--backport=BRANCH...] [--reviewer=NAME...]
+  ipatool [options] [-v...] pr-push PR_ID [--reviewer=NAME...] [--backport=BRANCH...] [--autobackport]
   ipatool [options] [-v...] pr-reject PR_ID --comment=TEXT
   ipatool [options] [-v...] backport PR_ID --branch=BRANCH...
 
@@ -77,6 +77,7 @@ iptool pr-push:
   Fetch all patches from pull request, store them in `patchdir` and call push.
 
   -B, --backport BRANCH Rebase patches from PR and open new PR against BRANCH
+  --autobackport        Automatically backport to branches indicated by PR labels
 
 ipatool backport:
   Fetch all patches from a pull request, store them in `patchdir` and backport
@@ -1128,7 +1129,11 @@ def pr_push_command(ctx):
             print("Closing pull request {}".format(pr.number))
             pr_is.close()
 
-            backport(ctx, ctx.options.get('--backport', []), repo, pr)
+            backport_branches = set(ctx.options.get('--backport', []))
+            if ctx.options['--autobackport']:
+                pat = re.compile(r'^ipa-\d+-\d+$')
+                backport_branches.update(l for l in labels if pat.match(l))
+            backport(ctx, backport_branches, repo, pr)
     finally:
         delete_patches(target_dir)
 


### PR DESCRIPTION
Add the --autobackport flag to the ipatool pr-push command.  When set, this
causes pr-push to automatically backport the PR to branches indicated in
the PR labels.

For now it defaults to off, but if it proves popular we could default it to
on in a later commit.