### PR TITLE
Document that the read:user permission is needed for the gh token

### DIFF
--- a/ipatool
+++ b/ipatool
@@ -134,7 +134,7 @@ browser: firefox
 
 # GitHub configuration
 # for the token, we require at least the 'repo', 'admin:org' group permissions
-# and the 'user:email' permission
+# and the 'user:email' and 'read:user' permissions
 gh-token: "0123456789abcdef0123456789abcdef01234567"
 gh-repo: "freeipa/freeipa"
 gh-fork-remote: "mygh"


### PR DESCRIPTION
This is used within the python3-github3py module to pull the
disk_usage, owned_private_repos, total_private_repos and plan
variables.