### PR TITLE
ipatool: use 3way merge for git am

### DIFF
--- a/ipatool
+++ b/ipatool
@@ -543,8 +543,11 @@ def apply_patches(ctx, patches, branch, die_on_fail=True):
                     '%s/%s' % (ctx.config['remote'], branch)])
     for patch in patches:
         print('Applying to %s: %s' % (branch, patch.subject))
-        res = ctx.runprocess(['git', 'am'], stdin_string=''.join(patch.lines),
-                             check_returncode=0 if die_on_fail else None)
+        res = ctx.runprocess(
+            ['git', 'am', '--3way'],
+            stdin_string=''.join(patch.lines),
+            check_returncode=0 if die_on_fail else None,
+        )
         if not die_on_fail and res.returncode:
             raise RuntimeError(res.stderr)
     sha1 = ctx.runprocess(['git', 'rev-parse', 'HEAD']).stdout.strip()


### PR DESCRIPTION
Patching sometimes fails.  Nothing gets applied (no changes to
working tree) and no failed hunk indication is given.  I do not
understand the reason.  Perhaps it is a quirk triggered by passing
the patch on stdin instead of as a file.

Experimentally, I found that supplying the `--3way' option to git am
fixed the problem (the problem that occurred for me, at least).