### PR TITLE
release-notes.py: Freenode => libera.chat.

### DIFF
--- a/release/release-notes.py
+++ b/release/release-notes.py
@@ -42,7 +42,7 @@ Upgrade instructions are available on [[Upgrade]] page.
 == Feedback ==
 Please provide comments, bugs and other feedback via the freeipa-users mailing
 list (https://lists.fedoraproject.org/archives/list/freeipa-users@lists.fedorahosted.org/)
-or #freeipa channel on Freenode.
+or #freeipa channel on libera.chat.
 
 """
 


### PR DESCRIPTION
The FreeIPA project has moved from Freenode to libera.chat.

Signed-off-by: François Cami <fcami@redhat.com>