### PR TITLE
Add Accept: */* to the request headers

### DIFF
--- a/ipatool
+++ b/ipatool
@@ -297,6 +297,7 @@ class Ticket(object):
         if self._data is not None:
             return self._data
         print('Retrieving ticket %s' % self.number)
+        self.pagure.session.headers['Accept'] = "*/*"
         self._data = self.pagure.issue_info(self.number)
         return self._data
 


### PR DESCRIPTION
Requests from libpagure were failing because Anubis was challenging our humanity. I don't know exactly why this makes it work again but I don't argue with success.