### PR TITLE
Mention sqlite-devel dependency to compile Rust

### DIFF
--- a/ipatool-rs/README.md
+++ b/ipatool-rs/README.md
@@ -7,7 +7,12 @@ managing GitHub pull requests.
 
 ## Building
 
+Make sure you've installed non-Rust dependencies:
+```sh
+dnf install sqlite-devel
 ```
+
+```sh
 cargo build --release
 # binary at target/release/ipatool
 ```


### PR DESCRIPTION
Without the devel libraries, you won't be able to link the Rust dependencies.