### PR TITLE
Setup forgejo as default tracker

### DIFF
--- a/ipatool-rs/README.md
+++ b/ipatool-rs/README.md
@@ -40,10 +40,10 @@ patchdir: ~/patches/to-apply
 # ── URL templates ─────────────────────────────────────────────────────────────
 
 # Base URL for Pagure/Forgejo issues.  The issue number is appended.
-ticket-url: https://pagure.io/freeipa/issue/
+ticket-url: https://codeberg.org/freeipa/freeipa/issues/
 
 # Base URL for upstream commit links included in comments.
-commit-url: https://pagure.io/freeipa/c/
+commit-url: https://codeberg.org/freeipa/freeipa/commit/
 
 # Base URL for Bugzilla bugs (appended with bug ID).
 bugzilla-bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=
@@ -52,20 +52,22 @@ bugzilla-bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=
 # automatically from the path prefix before "/browse/".
 jira-ticket-url: https://issues.redhat.com/browse/RHEL-
 
-# ── Pagure (primary issue tracker) ───────────────────────────────────────────
+# ── Pagure (legacy issue tracker) ───────────────────────────────────────────
 # Use either Pagure or Forgejo — not both.
 
-pagure-repository: freeipa
+# pagure-repository: freeipa
 # Create at https://pagure.io/<repo>/settings#apikeys
 # Required permissions: assign/change status/comment/create/subscribe/update
 # issues; create issues; update custom fields; update milestone.
-pagure-token: "0123456789abcdef0123456789abcdef01234567"
+# pagure-token: "0123456789abcdef0123456789abcdef01234567"
 
-# ── Forgejo (alternative issue tracker) ──────────────────────────────────────
+# ── Forgejo (primary issue tracker) ──────────────────────────────────────
 
-# forgejo-url: https://forgejo.example.com
-# forgejo-repo: owner/repository
-# forgejo-token: "0123456789abcdef0123456789abcdef01234567"
+forgejo-url: https://forgejo.example.com
+forgejo-repo: owner/repository
+# Create at https://codeberg.org/user/settings/applications
+# Required permissions: issue read/write, repository read/write
+forgejo-token: "0123456789abcdef0123456789abcdef01234567"
 
 # ── Issue tracker operations ──────────────────────────────────────────────────
 # Values: yes | no | ask  (ask = prompt interactively each time)

--- a/ipatool-rs/src/commands/mod.rs
+++ b/ipatool-rs/src/commands/mod.rs
@@ -25,7 +25,7 @@ pub mod push;
 pub mod queue_submit;
 pub mod start_review;
 
-pub const GIT_REMOTE_SERVER: &str = "pagure.io";
+pub const GIT_REMOTE_SERVER: &str = "codeberg.org";
 
 /// Milestone to branches mapping (regex → list of branches)
 pub fn milestone_branches(milestone: &str) -> Option<Vec<String>> {

--- a/ipatool-rs/src/main.rs
+++ b/ipatool-rs/src/main.rs
@@ -27,13 +27,13 @@ remote: origin
 patchdir: ~/patches/to-apply
 
 # URLs to use in reports & messages
-ticket-url: https://pagure.io/freeipa/issue/
-commit-url: https://pagure.io/freeipa/c/
+ticket-url: https://codeberg.org/freeipa/freeipa/issues/
+commit-url: https://codeberg.org/freeipa/freeipa/commit/
 bugzilla-bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=
 jira-ticket-url: https://issues.redhat.com/browse/RHEL-
 
-# Pagure login details (used as default issue tracker)
-pagure-repository: freeipa
+# Pagure login details (legacy issue tracker)
+# pagure-repository: freeipa
 # Create the token in https://pagure.io/freeipa/settings
 # For token you need:
 #   * Assign issue to someone
@@ -44,15 +44,17 @@ pagure-repository: freeipa
 #   * Update an issue, status, comments, custom fields...
 #   * Update the custom fields of an issue
 #   * Update the milestone of an issue
-pagure-token: "YOUR_PAGURE_TOKEN_HERE"
+# pagure-token: "YOUR_PAGURE_TOKEN_HERE"
 # workaround: pagure doesn't provide the tokens for users so we cannot
 # dynamically detect username
 username: username
 
-# Forgejo login details (alternative to Pagure for issue tracking)
-# forgejo-url: https://forgejo.example.com
-# forgejo-repo: owner/repository
-# forgejo-token: "YOUR_FORGEJO_TOKEN_HERE"
+# Forgejo login details (primary issue tracker)
+forgejo-url: https://forgejo.example.com
+forgejo-repo: owner/repository
+# Create at https://codeberg.org/user/settings/applications
+# Required permissions: issue read/write, repository read/write
+forgejo-token: "0123456789abcdef0123456789abcdef01234567"
 
 # Issue tracker operations (apply to both Pagure and Forgejo)
 # update-issue options: yes/no/ask


### PR DESCRIPTION
Updates README, warnings and issue tracker to forgejo as default. Keeps pagure as legacy tracker.